### PR TITLE
fix the unmatching .project file

### DIFF
--- a/.project
+++ b/.project
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.vmturbo.sdk.examples.storageProbe</name>
+	<name>com.vmturbo.sdk.examples</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
-		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
@@ -17,7 +12,6 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
Verified locally.

The .project file used to be wrong, and is causing problem while importing the project. Fixed the problem by replacing it with the right .project file. Import the new fold into eclipse, there is no error message.
